### PR TITLE
Fix: returning route parameters as an array

### DIFF
--- a/src/Router/Match/Http.php
+++ b/src/Router/Match/Http.php
@@ -299,7 +299,7 @@ class Http extends AbstractMatch
                 }
             }
         } else if ((null !== $this->dynamicRoute) && (count($this->segments) >= 3)) {
-            $this->routeParams = array_slice($this->segments, 2);
+            $this->routeParams = [array_slice($this->segments, 2)];
         }
     }
 


### PR DESCRIPTION
For dynamic routes, the number of parameters that are greater than or equal to 3, previously only the first parameter was returned as a string, or it was necessary to specifically call ```func_get_args()``` to retrieve the array.