### PR TITLE
Fix null offset deprecation in Http router when no route matches

### DIFF
--- a/src/Router/Match/Http.php
+++ b/src/Router/Match/Http.php
@@ -274,7 +274,7 @@ class Http extends AbstractMatch
      */
     protected function parseRouteParams(): void
     {
-        if (isset($this->preparedRoutes[$this->route]['params']) &&
+        if (($this->route !== null) && isset($this->preparedRoutes[$this->route]['params']) &&
             (count($this->preparedRoutes[$this->route]['params']) > 0)) {
             $offset = 0;
             foreach ($this->preparedRoutes[$this->route]['params'] as $i => $param) {

--- a/tests/RouterHttpTest.php
+++ b/tests/RouterHttpTest.php
@@ -135,6 +135,34 @@ class RouterHttpTest extends TestCase
         $this->assertStringContainsString('Page Not Found', $result);
     }
 
+    public function testHttpNoRouteFoundDoesNotEmitNullOffsetDeprecation()
+    {
+        $_SERVER['DOCUMENT_ROOT'] = realpath(getcwd());
+        $_SERVER['REQUEST_URI']   = '/foo';
+        $routes = [
+            '/bar' => [
+                'controller' => function() {
+                    echo 'Foo';
+                }
+            ]
+        ];
+
+        $deprecations = [];
+        set_error_handler(function ($errno, $errstr) use (&$deprecations) {
+            $deprecations[] = $errstr;
+            return true;
+        }, E_DEPRECATED);
+
+        $http = new Http();
+        $http->addRoutes($routes);
+        $http->match();
+
+        restore_error_handler();
+
+        $this->assertFalse($http->hasRoute());
+        $this->assertSame([], $deprecations);
+    }
+
     public function testHttpDefaultRoute()
     {
         $_SERVER['DOCUMENT_ROOT'] = realpath(getcwd());


### PR DESCRIPTION
## Summary
- `Router\Match\Http::$route` stays `null` when `match()` finds no matching route.
- `parseRouteParams()` unconditionally indexes `$this->preparedRoutes[$this->route]`, which triggers `Deprecated: Using null as an array offset is deprecated, use an empty string instead` on every unmatched request.
- This specific deprecation was introduced in **PHP 8.5** — confirmed empirically with an `E_DEPRECATED` error handler across 8.2.30, 8.4.16, and 8.5.0: it does not fire on 8.2 or 8.4, only on 8.5. Since this package requires `php >=8.3.0`, most current users won't see it yet, but it will affect anyone upgrading to 8.5.
- Added a `$this->route !== null` guard before the `isset()` check — no behavior change for the matched-route path, just avoids indexing with `null`.

## Test plan
- Added `testHttpNoRouteFoundDoesNotEmitNullOffsetDeprecation`, which installs an error handler for `E_DEPRECATED` around an unmatched `match()` call and asserts nothing is captured. Confirmed it fails on `master` under PHP 8.5 (reproduces the deprecation) and passes with this fix.
- Full suite: `vendor/bin/phpunit --no-coverage` → 179 tests, 455 assertions, all green.